### PR TITLE
Update ci to golang latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12.0
+      - image: circleci/golang
 
     steps:
       - checkout
@@ -12,9 +12,6 @@ jobs:
       - run:
           name: test
           command: |
-            export PATH="$GOBIN:$PATH"
-            go env
-            go version
             make test
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}


### PR DESCRIPTION
- update golang to 1.13 for ci and remove unneeded env sets

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>