### PR TITLE
memdb: test Iterator

### DIFF
--- a/mem_db_test.go
+++ b/mem_db_test.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemDB_Iterator(t *testing.T) {
+	db := NewMemDB()
+	defer db.Close()
+
+	// if db is empty, iterator is invalid
+	itr := db.Iterator(nil, nil)
+	defer itr.Close()
+	assert.False(t, itr.Valid())
+
+	db.Set([]byte("foo"), []byte("bar"))
+
+	// single iteration
+	itr := db.Iterator(nil, nil)
+	defer itr.Close()
+	assert.True(t, itr.Valid())
+	assert.Equal(t, []byte("foo"), itr.Key())
+	assert.Equal(t, []byte("bar"), itr.Value())
+	itr.Next()
+	assert.False(t, itr.Valid())
+}

--- a/mem_db_test.go
+++ b/mem_db_test.go
@@ -18,7 +18,7 @@ func TestMemDB_Iterator(t *testing.T) {
 	db.Set([]byte("foo"), []byte("bar"))
 
 	// single iteration
-	itr := db.Iterator(nil, nil)
+	itr = db.Iterator(nil, nil)
 	defer itr.Close()
 	assert.True(t, itr.Valid())
 	assert.Equal(t, []byte("foo"), itr.Key())


### PR DESCRIPTION
Thought I've found a bug, but it appeared that I simply forgot to call .Next() when iterating over range of keys 🦆 

Still more tests never killed anyone.