### PR TITLE
Remove unused import

### DIFF
--- a/c_level_db.go
+++ b/c_level_db.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/jmhodges/levigo"
-	"github.com/pkg/errors"
 )
 
 func init() {


### PR DESCRIPTION
Problem: An un-used import causes a compilation error (ie in ABCI apps) when using `-tags cleveldb`
Solution: Remove the un-used import.