### PR TITLE
Make GoLevelDB batch.Close() actually close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - [memdb] [\#56](https://github.com/tendermint/tm-db/pull/56) Use an RWMutex for improved performance with highly concurrent read-heavy workloads
 
+### Bug Fixes
+
+- [goleveldb] [\#58](https://github.com/tendermint/tm-db/pull/58) Make `Batch.Close()` actually remove the batch contents
+
 ## 0.4.1
 
 **2020-2-26**

--- a/backend_test.go
+++ b/backend_test.go
@@ -453,9 +453,8 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	batch.Close()
 	err = db.Delete([]byte("c"))
 	require.NoError(t, err)
-	// FIXME Disabled because goleveldb is failing this test currently
-	//err = batch.Write()
-	//require.NoError(t, err)
+	err = batch.Write()
+	require.NoError(t, err)
 	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}})
 
 	// it should be possible to re-close the batch

--- a/go_level_db.go
+++ b/go_level_db.go
@@ -196,8 +196,9 @@ func (mBatch *goLevelDBBatch) WriteSync() error {
 }
 
 // Implements Batch.
-// Close is no-op for goLevelDBBatch.
-func (mBatch *goLevelDBBatch) Close() {}
+func (mBatch *goLevelDBBatch) Close() {
+	mBatch.batch.Reset()
+}
 
 //----------------------------------------
 // Iterator


### PR DESCRIPTION
Fixes #57. Branched off of #56, rebase onto `master` once merged.