### PR TITLE
cleveldb: fix handling of empty iterator keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - [boltdb] Properly handle blank keys in iterators
 
+- [cleveldb] Fix handling of empty keys as iterator endpoints
+
 - [goleveldb] [\#58](https://github.com/tendermint/tm-db/pull/58) Make `Batch.Close()` actually remove the batch contents
 
 ## 0.4.1

--- a/cleveldb_iterator.go
+++ b/cleveldb_iterator.go
@@ -20,7 +20,7 @@ var _ Iterator = (*cLevelDBIterator)(nil)
 
 func newCLevelDBIterator(source *levigo.Iterator, start, end []byte, isReverse bool) *cLevelDBIterator {
 	if isReverse {
-		if end == nil {
+		if end == nil || len(end) == 0 {
 			source.SeekToLast()
 		} else {
 			source.Seek(end)
@@ -34,7 +34,7 @@ func newCLevelDBIterator(source *levigo.Iterator, start, end []byte, isReverse b
 			}
 		}
 	} else {
-		if start == nil {
+		if start == nil || len(start) == 0 {
 			source.SeekToFirst()
 		} else {
 			source.Seek(start)


### PR DESCRIPTION
New tests showed that empty iterator keys causes panics.