### PR TITLE
test: add test of batch reuse semantics

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -460,6 +460,19 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	// it should be possible to re-close the batch
 	batch.Close()
 
+	// it should also be possible to reuse a closed batch as if it were a new one
+	batch.Set([]byte("c"), []byte{3})
+	err = batch.Write()
+	require.NoError(t, err)
+	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}, "c": {3}})
+	batch.Close()
+
+	batch.Delete([]byte("c"))
+	err = batch.WriteSync()
+	require.NoError(t, err)
+	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}})
+	batch.Close()
+
 	// batches should also write changes in order
 	batch = db.NewBatch()
 	batch.Delete([]byte("a"))


### PR DESCRIPTION
This tests that a closed batch can be reused as if it were a new one. It is unclear if this is the semantics we want, the alternative is to panic/error on reuse. The latter option might be better for safety, but many of the current backends allow the former so it is less breaking.

Personally I don't have a strong opinion, we just have to choose one or the other.