### PR TITLE
test: properly close iterator in assertKeyValues()

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -504,6 +504,7 @@ func assertKeyValues(t *testing.T, db DB, expect map[string][]byte) {
 		require.NoError(t, iter.Error())
 		actual[string(iter.Key())] = iter.Value()
 	}
+	iter.Close()
 
 	assert.Equal(t, expect, actual)
 }


### PR DESCRIPTION
Fixes deadlocks with backends that have locking iterators (namely BoltDB).