### PR TITLE
memdb: take out read-lock during iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [\#71](https://github.com/tendermint/tm-db/pull/71) Closed or written batches can no longer be reused, all non-`Close()` calls will panic
 
+- [memdb] `Iterator()` and `ReverseIterator()` now take out database read locks for the duration of the iteration
+
 - [memdb] [\#56](https://github.com/tendermint/tm-db/pull/56) Removed some exported methods that were mainly meant for internal use: `Mutex()`, `SetNoLock()`, `SetNoLockSync()`, `DeleteNoLock()`, and `DeleteNoLockSync()`
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [\#71](https://github.com/tendermint/tm-db/pull/71) Closed or written batches can no longer be reused, all non-`Close()` calls will panic
 
-- [memdb] `Iterator()` and `ReverseIterator()` now take out database read locks for the duration of the iteration
+- [memdb] [\#74](https://github.com/tendermint/tm-db/pull/74) `Iterator()` and `ReverseIterator()` now take out database read locks for the duration of the iteration
 
 - [memdb] [\#56](https://github.com/tendermint/tm-db/pull/56) Removed some exported methods that were mainly meant for internal use: `Mutex()`, `SetNoLock()`, `SetNoLockSync()`, `DeleteNoLock()`, and `DeleteNoLockSync()`
 

--- a/memdb.go
+++ b/memdb.go
@@ -154,11 +154,13 @@ func (db *MemDB) NewBatch() Batch {
 }
 
 // Iterator implements DB.
+// Takes out a read-lock on the database until the iterator is closed.
 func (db *MemDB) Iterator(start, end []byte) (Iterator, error) {
 	return newMemDBIterator(db, start, end, false), nil
 }
 
 // ReverseIterator implements DB.
+// Takes out a read-lock on the database until the iterator is closed.
 func (db *MemDB) ReverseIterator(start, end []byte) (Iterator, error) {
 	return newMemDBIterator(db, start, end, true), nil
 }

--- a/memdb.go
+++ b/memdb.go
@@ -155,14 +155,10 @@ func (db *MemDB) NewBatch() Batch {
 
 // Iterator implements DB.
 func (db *MemDB) Iterator(start, end []byte) (Iterator, error) {
-	db.mtx.RLock()
-	defer db.mtx.RUnlock()
-	return newMemDBIterator(db.btree, start, end, false), nil
+	return newMemDBIterator(db, start, end, false), nil
 }
 
 // ReverseIterator implements DB.
 func (db *MemDB) ReverseIterator(start, end []byte) (Iterator, error) {
-	db.mtx.RLock()
-	defer db.mtx.RUnlock()
-	return newMemDBIterator(db.btree, start, end, true), nil
+	return newMemDBIterator(db, start, end, true), nil
 }


### PR DESCRIPTION
B-tree may panic if it is changed during iteration, so we take out a read-lock for the duration.

No tests, since concurrency semantics are undefined and differ across backends (see #62).