### PR TITLE
godoc: emphasize read-only key/value slices, tweak interface docs

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -81,6 +81,10 @@ func testBackendGetSetDelete(t *testing.T, backend BackendType) {
 	value, err = db.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, value)
+
+	// Delete missing key.
+	err = db.Delete([]byte{9})
+	require.NoError(t, err)
 }
 
 func TestBackendsGetSetDelete(t *testing.T) {

--- a/memdb.go
+++ b/memdb.go
@@ -43,6 +43,11 @@ func newPair(key, value []byte) *item {
 }
 
 // MemDB is an in-memory database backend using a B-tree for storage.
+//
+// For performance reasons, all given and returned keys and values are pointers to the in-memory
+// database, so modifying them will cause the stored values to be modified as well. All DB methods
+// already specify that keys and values should be considered read-only, but this is especially
+// important with MemDB.
 type MemDB struct {
 	mtx   sync.RWMutex
 	btree *btree.BTree

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -6,6 +6,11 @@ const (
 	strChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" // 62 characters
 )
 
+// For testing convenience.
+func bz(s string) []byte {
+	return []byte(s)
+}
+
 // Str constructs a random alphanumeric string of given length.
 func randStr(length int) string {
 	chars := []byte{}

--- a/util.go
+++ b/util.go
@@ -5,6 +5,15 @@ import (
 	"os"
 )
 
+// We defensively turn nil keys or values into []byte{} for
+// most operations.
+func nonNilBytes(bz []byte) []byte {
+	if bz == nil {
+		return []byte{}
+	}
+	return bz
+}
+
 func cp(bz []byte) (ret []byte) {
 	ret = make([]byte, len(bz))
 	copy(ret, bz)


### PR DESCRIPTION
Emphasize that key/value byte slices (both given and returned) are read-only and must not be modified by callers. This is especially important with MemDB, where doing so will modify the value stored in the database - for performance, we do not implicitly copy slices. This can introduce subtle bugs, see e.g. #86.

Also cleans up the interface documentation a bit.