### PR TITLE
batch: return errors for all operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Batch `Set()`, `Delete()`, and `Close()` may now error (@erikgrinaker)
+
+- The `SetDeleter` interface has been removed (@erikgrinaker)
+
 ## 0.5.1
 
 **2020-03-30**

--- a/backend_test.go
+++ b/backend_test.go
@@ -458,12 +458,12 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	require.NoError(t, err)
 	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}, "c": {3}})
 
-	// trying to modify or rewrite a written batch should panic, but closing it should work
-	require.Panics(t, func() { batch.Set([]byte("a"), []byte{9}) })
-	require.Panics(t, func() { batch.Delete([]byte("a")) })
-	require.Panics(t, func() { batch.Write() })     // nolint: errcheck
-	require.Panics(t, func() { batch.WriteSync() }) // nolint: errcheck
-	batch.Close()
+	// trying to modify or rewrite a written batch should error, but closing it should work
+	require.Error(t, batch.Set([]byte("a"), []byte{9}))
+	require.Error(t, batch.Delete([]byte("a")))
+	require.Error(t, batch.Write())
+	require.Error(t, batch.WriteSync())
+	require.NoError(t, batch.Close())
 
 	// batches should write changes in order
 	batch = db.NewBatch()
@@ -505,11 +505,11 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	batch.Close()
 	batch.Close()
 
-	// all other operations on a closed batch should panic
-	require.Panics(t, func() { batch.Set([]byte("a"), []byte{9}) })
-	require.Panics(t, func() { batch.Delete([]byte("a")) })
-	require.Panics(t, func() { batch.Write() })     // nolint: errcheck
-	require.Panics(t, func() { batch.WriteSync() }) // nolint: errcheck
+	// all other operations on a closed batch should error
+	require.Error(t, batch.Set([]byte("a"), []byte{9}))
+	require.Error(t, batch.Delete([]byte("a")))
+	require.Error(t, batch.Write())
+	require.Error(t, batch.WriteSync())
 }
 
 func assertKeyValues(t *testing.T, db DB, expect map[string][]byte) {

--- a/prefixdb_batch.go
+++ b/prefixdb_batch.go
@@ -15,15 +15,15 @@ func newPrefixBatch(prefix []byte, source Batch) prefixDBBatch {
 }
 
 // Set implements Batch.
-func (pb prefixDBBatch) Set(key, value []byte) {
+func (pb prefixDBBatch) Set(key, value []byte) error {
 	pkey := append(cp(pb.prefix), key...)
-	pb.source.Set(pkey, value)
+	return pb.source.Set(pkey, value)
 }
 
 // Delete implements Batch.
-func (pb prefixDBBatch) Delete(key []byte) {
+func (pb prefixDBBatch) Delete(key []byte) error {
 	pkey := append(cp(pb.prefix), key...)
-	pb.source.Delete(pkey)
+	return pb.source.Delete(pkey)
 }
 
 // Write implements Batch.
@@ -37,6 +37,6 @@ func (pb prefixDBBatch) WriteSync() error {
 }
 
 // Close implements Batch.
-func (pb prefixDBBatch) Close() {
-	pb.source.Close()
+func (pb prefixDBBatch) Close() error {
+	return pb.source.Close()
 }

--- a/remotedb/batch.go
+++ b/remotedb/batch.go
@@ -7,6 +7,8 @@ import (
 	protodb "github.com/tendermint/tm-db/remotedb/proto"
 )
 
+var errBatchClosed = errors.New("batch has been written or closed")
+
 type batch struct {
 	db  *RemoteDB
 	ops []*protodb.Operation
@@ -21,35 +23,37 @@ func newBatch(rdb *RemoteDB) *batch {
 	}
 }
 
-func (b *batch) assertOpen() {
-	if b.ops == nil {
-		panic("batch has been written or closed")
-	}
-}
-
 // Set implements Batch.
-func (b *batch) Set(key, value []byte) {
-	b.assertOpen()
+func (b *batch) Set(key, value []byte) error {
+	if b.ops == nil {
+		return errBatchClosed
+	}
 	op := &protodb.Operation{
 		Entity: &protodb.Entity{Key: key, Value: value},
 		Type:   protodb.Operation_SET,
 	}
 	b.ops = append(b.ops, op)
+	return nil
 }
 
 // Delete implements Batch.
-func (b *batch) Delete(key []byte) {
-	b.assertOpen()
+func (b *batch) Delete(key []byte) error {
+	if b.ops == nil {
+		return errBatchClosed
+	}
 	op := &protodb.Operation{
 		Entity: &protodb.Entity{Key: key},
 		Type:   protodb.Operation_DELETE,
 	}
 	b.ops = append(b.ops, op)
+	return nil
 }
 
 // Write implements Batch.
 func (b *batch) Write() error {
-	b.assertOpen()
+	if b.ops == nil {
+		return errBatchClosed
+	}
 	_, err := b.db.dc.BatchWrite(b.db.ctx, &protodb.Batch{Ops: b.ops})
 	if err != nil {
 		return errors.Errorf("remoteDB.BatchWrite: %v", err)
@@ -61,17 +65,19 @@ func (b *batch) Write() error {
 
 // WriteSync implements Batch.
 func (b *batch) WriteSync() error {
-	b.assertOpen()
+	if b.ops == nil {
+		return errBatchClosed
+	}
 	_, err := b.db.dc.BatchWriteSync(b.db.ctx, &protodb.Batch{Ops: b.ops})
 	if err != nil {
 		return errors.Errorf("RemoteDB.BatchWriteSync: %v", err)
 	}
 	// Make sure batch cannot be used afterwards. Callers should still call Close(), for errors.
-	b.Close()
-	return nil
+	return b.Close()
 }
 
 // Close implements Batch.
-func (b *batch) Close() {
+func (b *batch) Close() error {
 	b.ops = nil
+	return nil
 }

--- a/remotedb/grpcdb/server.go
+++ b/remotedb/grpcdb/server.go
@@ -214,9 +214,15 @@ func (s *server) batchWrite(c context.Context, b *protodb.Batch, sync bool) (*pr
 	for _, op := range b.Ops {
 		switch op.Type {
 		case protodb.Operation_SET:
-			bat.Set(op.Entity.Key, op.Entity.Value)
+			err := bat.Set(op.Entity.Key, op.Entity.Value)
+			if err != nil {
+				return nil, err
+			}
 		case protodb.Operation_DELETE:
-			bat.Delete(op.Entity.Key)
+			err := bat.Delete(op.Entity.Key)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if sync {


### PR DESCRIPTION
Modify batch `Set`, `Delete`, and `Close` to return errors. The main error condition currently is using closed batches, but future ones include databases which implement batches as transactions (e.g. BadgerDB) and rejecting empty keys (#2).