### PR TITLE
lint: bump golangci to 1.29

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: golangci/golangci-lint-action@master
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.26
+          version: v1.29
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
Required by the GitHub lint action.