### PR TITLE
badgerdb: add build tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: test & coverage report creation
         run: |
-          go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic -tags cleveldb,boltdb,rocksdb -v
+          go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic -tags cleveldb,boltdb,rocksdb,badgerdb -v
       - uses: codecov/codecov-action@v1
         with:
           file: ./coverage.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [\#115](https://github.com/tendermint/tm-db/pull/115) Add a `BadgerDB` backend (@mvdan)
+- [\#115](https://github.com/tendermint/tm-db/pull/115) Add a `BadgerDB` backend with build tag `badgerdb` (@mvdan)
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Go 1.13+
 
 - **[RocksDB](https://github.com/tecbot/gorocksdb) [experimental]:** A [Go wrapper](https://github.com/tecbot/gorocksdb) around [RocksDB](https://rocksdb.org). Similarly to LevelDB (above) it uses LSM-trees for on-disk storage, but is optimized for fast storage media such as SSDs and memory. Supports atomic transactions, but not full ACID transactions.
 
-- **[BadgerDB](https://github.com/dgraph-io/badger) [experimental]:** A key-value database written as a pure-Go alternative to others like LevelDB and RocksDB. Makes use of multiple goroutines for performance, and includes advanced features such as transactions, write batches, compression, and more.
+- **[BadgerDB](https://github.com/dgraph-io/badger) [experimental]:** A key-value database written as a pure-Go alternative to e.g. LevelDB and RocksDB, with LSM-tree storage. Makes use of multiple goroutines for performance, and includes advanced features such as serializable ACID transactions, write batches, compression, and more.
 
 ## Meta-databases
 

--- a/badger_db.go
+++ b/badger_db.go
@@ -1,3 +1,5 @@
+// +build badgerdb
+
 package db
 
 import (

--- a/makefile
+++ b/makefile
@@ -24,9 +24,13 @@ test-boltdb:
 	@echo "--> Running go test"
 	@go test $(PACKAGES) -tags boltdb -v
 
+test-badgerdb:
+	@echo "--> Running go test"
+	@go test $(PACKAGES) -tags badgerdb -v
+
 test-all:
 	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags cleveldb,boltdb,rocksdb -v
+	@go test $(PACKAGES) -tags cleveldb,boltdb,rocksdb,badgerdb -v
 
 lint:
 	@echo "--> Running linter"


### PR DESCRIPTION
BadgerDB is pretty heavy, let's not include it by default. Related to #113.