### PR TITLE
boltdb: Issue with iterator / batching

### DIFF
--- a/boltdb_test.go
+++ b/boltdb_test.go
@@ -20,6 +20,88 @@ func TestBoltDBNewBoltDB(t *testing.T) {
 	db.Close()
 }
 
+func TestBoltDBBatchSmallNumberFails(t *testing.T) {
+	var txs int64 = 10
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	defer cleanupDBDir(dir, name)
+
+	db, err := NewBoltDB(name, dir)
+	require.NoError(t, err)
+
+	for i := int64(1); i < txs; i++ {
+		require.NoError(t, db.SetSync(int642Bytes(i), int642Bytes(i)))
+	}
+
+	iter, err := db.ReverseIterator(int642Bytes(int64(1)), int642Bytes(txs))
+	require.NoError(t, err)
+	defer iter.Close()
+
+	deleteBatch := db.NewBatch()
+	defer deleteBatch.Close()
+
+	for ;iter.Valid(); iter.Next() {
+		err := deleteBatch.Delete(iter.Key())
+		require.NoError(t, err)
+	}
+	require.NoError(t, iter.Error())
+
+	require.NoError(t, deleteBatch.WriteSync())
+}
+
+func TestBoltDBBatchLargeNumberPasses(t *testing.T) {
+	var txs int64 = 1000
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	defer cleanupDBDir(dir, name)
+
+	db, err := NewBoltDB(name, dir)
+	require.NoError(t, err)
+
+	for i := int64(1); i < txs; i++ {
+		require.NoError(t, db.SetSync(int642Bytes(i), int642Bytes(i)))
+	}
+
+	iter, err := db.ReverseIterator(int642Bytes(int64(1)), int642Bytes(txs))
+	require.NoError(t, err)
+	defer iter.Close()
+
+	deleteBatch := db.NewBatch()
+	defer deleteBatch.Close()
+
+	for ;iter.Valid(); iter.Next() {
+		err := deleteBatch.Delete(iter.Key())
+		require.NoError(t, err)
+	}
+	require.NoError(t, iter.Error())
+
+	require.NoError(t, deleteBatch.WriteSync())
+}
+
+func TestBoltDBBatchNoIteratorPasses(t *testing.T) {
+	var txs int64 = 10
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	defer cleanupDBDir(dir, name)
+
+	db, err := NewBoltDB(name, dir)
+	require.NoError(t, err)
+
+	for i := int64(1); i < txs; i++ {
+		require.NoError(t, db.SetSync(int642Bytes(i), int642Bytes(i)))
+	}
+
+	deleteBatch := db.NewBatch()
+	defer deleteBatch.Close()
+
+	for i := int64(1); i < txs; i++ {
+		err := deleteBatch.Delete(int642Bytes(i))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, deleteBatch.WriteSync())
+}
+
 func BenchmarkBoltDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	db, err := NewBoltDB(name, "")


### PR DESCRIPTION
This is more of an issue than a PR containing a solution but I find that adding some code might help to explain the situation I'm trying to get to the bottom of.

This originally relates to a problem with pruning in Tendermint where the node would stall after a few heights of pruning.

The problem came about after introducing an iterator to prune state

It seemed however that this was only happening with boltdb so I tried to write some basic unit tests to catch it. 

I still haven't figured what the root cause is but it seems to halt when there is an iterator and it seems that it's getting deadlocked because of a mutex which potentially it isn't releasing every time a batch operation is done. The stack trace for the first test is printed out here 

```
panic: test timed out after 5s

goroutine 21 [running]:
testing.(*M).startAlarm.func1()
        /usr/local/go/src/testing/testing.go:1618 +0xe5
created by time.goFunc
        /usr/local/go/src/time/sleep.go:167 +0x45

goroutine 1 [chan receive]:
testing.(*T).Run(0xc000106600, 0x6d98ab, 0x1f, 0x6e6048, 0x48dd01)
        /usr/local/go/src/testing/testing.go:1169 +0x2da
testing.runTests.func1(0xc000106480)
        /usr/local/go/src/testing/testing.go:1439 +0x78
testing.tRunner(0xc000106480, 0xc00017bde0)
        /usr/local/go/src/testing/testing.go:1123 +0xef
testing.runTests(0xc000130420, 0x895000, 0x1a, 0x1a, 0xbffc7abbfa4b8657, 0x12a0fb4f9, 0x89a520, 0x40efd0)
        /usr/local/go/src/testing/testing.go:1437 +0x2fe
testing.(*M).Run(0xc00014a100, 0x0)
        /usr/local/go/src/testing/testing.go:1345 +0x1eb
main.main()
        _testmain.go:103 +0x138

goroutine 19 [chan receive]:
go.etcd.io/bbolt.(*DB).Batch(0xc000184600, 0xc000113320, 0xc000106600, 0x0)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/db.go:770 +0x1ec
github.com/tendermint/tm-db.(*boltDBBatch).Write(0xc000130ee0, 0x0, 0x1)
        /home/callum/go/src/github.com/tendermint/tm-db/boltdb_batch.go:54 +0x85
github.com/tendermint/tm-db.(*boltDBBatch).WriteSync(0xc000130ee0, 0xc000106600, 0x0)
        /home/callum/go/src/github.com/tendermint/tm-db/boltdb_batch.go:79 +0x2b
github.com/tendermint/tm-db.TestBoltDBBatchSmallNumberFails(0xc000106600)
        /home/callum/go/src/github.com/tendermint/tm-db/boltdb_test.go:49 +0x586
testing.tRunner(0xc000106600, 0x6e6048)
        /usr/local/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1168 +0x2b3

goroutine 20 [semacquire]:
sync.runtime_SemacquireMutex(0xc0001847c8, 0x0, 0x0)
        /usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*RWMutex).Lock(0xc0001847c0)
        /usr/local/go/src/sync/rwmutex.go:103 +0x85
go.etcd.io/bbolt.(*DB).mmap(0xc000184600, 0x8000, 0x0, 0x0)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/db.go:329 +0x69
go.etcd.io/bbolt.(*DB).allocate(0xc000184600, 0x52, 0x1, 0x51, 0xc000125240, 0x0)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/db.go:939 +0x13f
go.etcd.io/bbolt.(*Tx).allocate(0xc000194a80, 0x1, 0x7fc0a8011000, 0x8cba20, 0x0)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/tx.go:498 +0x4a
go.etcd.io/bbolt.(*node).spill(0xc0001a27e0, 0xc000041be0, 0x2)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/node.go:364 +0x275
go.etcd.io/bbolt.(*Bucket).spill(0xc000194a98, 0x20be04f, 0x89a520)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/bucket.go:570 +0x497
go.etcd.io/bbolt.(*Tx).Commit(0xc000194a80, 0x0, 0x0)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/tx.go:160 +0xee
go.etcd.io/bbolt.(*DB).Update(0xc000184600, 0xc000041f08, 0x0, 0x0)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/db.go:701 +0x105
go.etcd.io/bbolt.(*batch).run(0xc000125180)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/db.go:809 +0x125
sync.(*Once).doSlow(0xc000125190, 0xc00002e7a8)
        /usr/local/go/src/sync/once.go:66 +0xec
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:57
go.etcd.io/bbolt.(*batch).trigger(0xc000125180)
        /home/callum/go/pkg/mod/go.etcd.io/bbolt@v1.3.5/db.go:791 +0x65
created by time.goFunc
        /usr/local/go/src/time/sleep.go:167 +0x45
exit status 2
FAIL    github.com/tendermint/tm-db     5.008s
```

To reproduce run something like:
```
❯ while true; do go test -run TestBoltDBBatchSmallNumberFails -tags boltdb -timeout 5s -count 1; done
```

