### PR TITLE
Add an option to create MemDB iterators with no Mutex for the CacheKVStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 .idea
+vendor/*

--- a/memdb.go
+++ b/memdb.go
@@ -190,3 +190,19 @@ func (db *MemDB) ReverseIterator(start, end []byte) (Iterator, error) {
 	}
 	return newMemDBIterator(db, start, end, true), nil
 }
+
+// IteratorNoMtx makes an iterator with no mutex.
+func (db *MemDB) IteratorNoMtx(start, end []byte) (Iterator, error) {
+	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
+		return nil, errKeyEmpty
+	}
+	return newMemDBIteratorMtxChoice(db, start, end, false, false), nil
+}
+
+// ReverseIteratorNoMtx makes an iterator with no mutex.
+func (db *MemDB) ReverseIteratorNoMtx(start, end []byte) (Iterator, error) {
+	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
+		return nil, errKeyEmpty
+	}
+	return newMemDBIteratorMtxChoice(db, start, end, true, false), nil
+}


### PR DESCRIPTION
This is what we should be using in the SDK for the memDB CacheKVStore invocation there, to get the same guarantees around iterator closing as is present now. (Also this is just faster)

After this, I'll submit a PR that significantly improves performance of Next operation. (Removes lots of mutex ticking time)