### PR TITLE
Retract the accidentally-released v0.6.5.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tm-db
 
-go 1.12
+go 1.16
 
 require (
 	github.com/dgraph-io/badger/v2 v2.2007.3
@@ -16,3 +16,6 @@ require (
 	go.etcd.io/bbolt v1.3.6
 	google.golang.org/grpc v1.38.0
 )
+
+// Breaking changes were released with the wrong tag (use v0.6.4).
+retract v0.6.5

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	google.golang.org/grpc v1.38.0
 )
 
-// Breaking changes were released with the wrong tag (use v0.6.4).
+// Breaking changes were released with the wrong tag (use v0.6.6 or later).
 retract v0.6.5


### PR DESCRIPTION
Update the go.mod file to version 1.16, to allow the retract syntax.

~Requires #195 (or equivalent) to be merged first.~

In addition to this, I think we should move this release into a separate branch, revert the changes from master, and cut a v0.6.6 as a successor to v0.6.4 so that we can still have a viable mainline for bug fixes and such.