### PR TITLE
Update mergify configuration.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,15 @@
+queue_rules:
+  - name: default
+    conditions:
+      - base=master
+      - label=S:automerge
+
 pull_request_rules:
   - name: automerge to master with label S:automerge and branch protection passing
     conditions:
       - base=master
       - label=S:automerge
     actions:
-      merge:
-        method: squash
-        strict: true
+      queue:
+        method: merge
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,5 +11,5 @@ pull_request_rules:
       - label=S:automerge
     actions:
       queue:
-        method: merge
+        method: squash
         name: default


### PR DESCRIPTION
Per https://blog.mergify.com/strict-mode-deprecation/, the "strict" mode
has been deprecated and will be turned off on 10-Jan-2022. This updates
the config to use the new, approved thing instead of the old thing.