### PR TITLE
Revert rocksdb version at tip.

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 FROM build AS install
 ARG LEVELDB=1.20
-ARG ROCKSDB=6.24.2
+ARG ROCKSDB=6.6.4
 
 # Install cleveldb
 RUN \


### PR DESCRIPTION
I tried to fold in the change from #197, but it causes Go build
failures due to an incompatible C API. Roll back the version to
the previous one, we can upgrade separately.