### PR TITLE
cosmos/gorocksdb in the imports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,7 @@ jobs:
     container: tendermintdev/docker-tm-db-testing
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2.5.2
+      - uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be
-          # specified without patch version: we always use the latest patch
-          # version.
-          version: v1.30
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
     # - godox
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
@@ -24,7 +24,6 @@ linters:
     # - interfacer
     - lll
     - misspell
-    - maligned
     - nakedret
     - prealloc
     # - scopelint

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Go 1.13+
 
 - **[BoltDB](https://github.com/etcd-io/bbolt) [experimental]:** A [fork](https://github.com/etcd-io/bbolt) of [BoltDB](https://github.com/boltdb/bolt). Uses B+trees for on-disk storage, which have good performance for read-heavy workloads and range scans. Supports serializable ACID transactions.
 
-- **[RocksDB](https://github.com/tecbot/gorocksdb) [experimental]:** A [Go wrapper](https://github.com/tecbot/gorocksdb) around [RocksDB](https://rocksdb.org). Similarly to LevelDB (above) it uses LSM-trees for on-disk storage, but is optimized for fast storage media such as SSDs and memory. Supports atomic transactions, but not full ACID transactions.
+- **[RocksDB](https://github.com/cosmos/gorocksdb) [experimental]:** A [Go wrapper](https://github.com/cosmos/gorocksdb) around [RocksDB](https://rocksdb.org). Similarly to LevelDB (above) it uses LSM-trees for on-disk storage, but is optimized for fast storage media such as SSDs and memory. Supports atomic transactions, but not full ACID transactions.
 
 - **[BadgerDB](https://github.com/dgraph-io/badger) [experimental]:** A key-value database written as a pure-Go alternative to e.g. LevelDB and RocksDB, with LSM-tree storage. Makes use of multiple goroutines for performance, and includes advanced features such as serializable ACID transactions, write batches, compression, and more.
 

--- a/common_test.go
+++ b/common_test.go
@@ -127,7 +127,7 @@ func benchmarkRandomReadsWrites(b *testing.B, db DB) {
 			val := internal[idx]
 			idxBytes := int642Bytes(idx)
 			valBytes := int642Bytes(val)
-			//fmt.Printf("Set %X -> %X\n", idxBytes, valBytes)
+			// fmt.Printf("Set %X -> %X\n", idxBytes, valBytes)
 			err := db.Set(idxBytes, valBytes)
 			if err != nil {
 				// require.NoError() is very expensive (according to profiler), so check manually
@@ -145,7 +145,7 @@ func benchmarkRandomReadsWrites(b *testing.B, db DB) {
 				// require.NoError() is very expensive (according to profiler), so check manually
 				b.Fatal(b, err)
 			}
-			//fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
+			// fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
 			if valExp == 0 {
 				if !bytes.Equal(valBytes, nil) {
 					b.Errorf("Expected %v for %v, got %X", nil, idx, valBytes)

--- a/common_test.go
+++ b/common_test.go
@@ -127,7 +127,6 @@ func benchmarkRandomReadsWrites(b *testing.B, db DB) {
 			val := internal[idx]
 			idxBytes := int642Bytes(idx)
 			valBytes := int642Bytes(val)
-			// fmt.Printf("Set %X -> %X\n", idxBytes, valBytes)
 			err := db.Set(idxBytes, valBytes)
 			if err != nil {
 				// require.NoError() is very expensive (according to profiler), so check manually

--- a/common_test.go
+++ b/common_test.go
@@ -144,7 +144,6 @@ func benchmarkRandomReadsWrites(b *testing.B, db DB) {
 				// require.NoError() is very expensive (according to profiler), so check manually
 				b.Fatal(b, err)
 			}
-			// fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
 			if valExp == 0 {
 				if !bytes.Equal(valBytes, nil) {
 					b.Errorf("Expected %v for %v, got %X", nil, idx, valBytes)

--- a/db.go
+++ b/db.go
@@ -28,7 +28,7 @@ const (
 	//   - may be faster is some use-cases (random reads - indexer)
 	//   - use boltdb build tag (go build -tags boltdb)
 	BoltDBBackend BackendType = "boltdb"
-	// RocksDBBackend represents rocksdb (uses github.com/tecbot/gorocksdb)
+	// RocksDBBackend represents rocksdb (uses github.com/cosmos/gorocksdb)
 	//   - EXPERIMENTAL
 	//   - requires gcc
 	//   - use rocksdb build tag (go build -tags rocksdb)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/tendermint/tm-db
 go 1.17
 
 require (
+	github.com/cosmos/gorocksdb v1.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/btree v1.0.0
 	github.com/jmhodges/levigo v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
-	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c
 	go.etcd.io/bbolt v1.3.6
 	google.golang.org/grpc v1.43.0
 )
@@ -35,7 +35,3 @@ require (
 
 // Breaking changes were released with the wrong tag (use v0.6.6 or later).
 retract v0.6.5
-
-// Note: gorocksdb bindings for OptimisticTransactionDB are not merged upstream, so we use a fork
-// See https://github.com/tecbot/gorocksdb/pull/216
-replace github.com/tecbot/gorocksdb => github.com/cosmos/gorocksdb v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/cosmos/gorocksdb v1.1.1 h1:N0OqpEKXgsi2qtDm8T1+AlNMXkTm6s1jowYf7/4pH5I=
-github.com/cosmos/gorocksdb v1.1.1/go.mod h1:b/U29r/CtguX3TF7mKG1Jjn4APDqh4wECshxXdiWHpA=
+github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
+github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/tecbot/gorocksdb"
+	"github.com/cosmos/gorocksdb"
 )
 
 func init() {

--- a/rocksdb_batch.go
+++ b/rocksdb_batch.go
@@ -2,7 +2,7 @@
 
 package db
 
-import "github.com/tecbot/gorocksdb"
+import "github.com/cosmos/gorocksdb"
 
 type rocksDBBatch struct {
 	db    *RocksDB

--- a/rocksdb_iterator.go
+++ b/rocksdb_iterator.go
@@ -5,7 +5,7 @@ package db
 import (
 	"bytes"
 
-	"github.com/tecbot/gorocksdb"
+	"github.com/cosmos/gorocksdb"
 )
 
 type rocksDBIterator struct {

--- a/util_test.go
+++ b/util_test.go
@@ -113,7 +113,7 @@ func TestPrefixIteratorMatches1N(t *testing.T) {
 			// Bad!
 			checkNext(t, itr, false)
 
-			//Once invalid...
+			// Once invalid...
 			checkInvalid(t, itr)
 		})
 	}


### PR DESCRIPTION
* updates .golangci-lint.yml
* uses cosmos/gorocksdb everywhere preventing replace statements downstream
* removes the version number from golanci-lint so that we're always using the latest version (earlier one was dated and it couldn't run because it didn't recognize `revive`)