### PR TITLE
Update rocksdb.go

### DIFF
--- a/rocksdb.go
+++ b/rocksdb.go
@@ -37,6 +37,8 @@ func NewRocksDB(name string, dir string) (*RocksDB, error) {
 
 	opts := gorocksdb.NewDefaultOptions()
 	opts.SetBlockBasedTableFactory(bbto)
+	// SetMaxOpenFiles to 4096 seems to provide a reliable performance boost
+	opts.SetMaxOpenFiles(4096)
 	opts.SetCreateIfMissing(true)
 	opts.IncreaseParallelism(runtime.NumCPU())
 	// 1.5GB maximum memory use for writebuffer.


### PR DESCRIPTION
Today I'm working to make rocks an acceptable default, and this seems to help.  I got some of this from terra's work on tm-db.

If desired, I could merge my version of this with more options illustrated for the user, but commented out:

https://github.com/notional-labs/tm-db/blob/rocks-tuning/rocksdb.go


I should also highlight Terra's work here:

https://github.com/tendermint/tm-db/compare/master...terra-money:performance

And finally I should mention that a company that specalizes in rocksdb performance enhancements has reached out to me.  I bungled scheduling last week, reckon they will end up reading this PR, and hope to succeed with scheduling this week. 

I figure it's helpful for me to show exactly what I am working on and with-- basically, Juno has has a longstanding sync issue.  So I am trying to make it possible to do a pure-rocks node with Osmosis' iavl updates.  This way, it'll be as easy as possible for people to set up archives.  

I'm then going to go through every version of juno and apply the changes.  So far, Terra's work seems to perform best. 

Currently I am always talking in generalities.  I am not sure what the best way to look at this stuff is:

* blocks per second synced?
* queries per second against a fully synced archive node without making the node fall behind the tip?
* something else?

Happy to compare notes with anyone. 

Furthermore, it's notable that this will immediately apply to any 44 series chain, including osmosis and gaia. 