### PR TITLE
Use ghcr.io and build docker for arm, too

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tendermintdev/docker-tm-db-testing
+          DOCKER_IMAGE=ghcr.io/tendermint/tm-db
           VERSION=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -41,11 +41,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
+      -
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to Docker Hub
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@
 # For that reason, changes here should be done in a separate PR in advance of
 # work that depends on them.
 
-name: Build & Push TM-DB-Testing
+name: Build & Push TM-DB Docker image
 on:
   pull_request:
     paths:
@@ -49,10 +49,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
+      - name: Publish to ghcr.io
         uses: docker/build-push-action@v3
         with:
           context: ./tools
           file: ./tools/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
This PR moves the docker images away from docker hub, to the github container registry, making them more visible.

Additionally for greater ease of use for devs on M1 Macs, this PR also makes a multiplatform docker container.