### PR TITLE
Goleveldb settings from omnibus

### DIFF
--- a/goleveldb.go
+++ b/goleveldb.go
@@ -24,8 +24,31 @@ type GoLevelDB struct {
 var _ DB = (*GoLevelDB)(nil)
 
 func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
-	return NewGoLevelDBWithOpts(name, dir, nil)
-}
+	o := &opt.Options{
+		// The default value is nil
+		Filter: filter.NewBloomFilter(10),
+		// Use 1 GiB instead of default 8 MiB
+		BlockCacheCapacity: opt.GiB,
+		// Use 64 MiB instead of default 4 MiB
+		WriteBuffer:            64 * opt.MiB,
+		DisableSeeksCompaction: true,
+		OpenFilesCacheCapacity: DefaultOpenFilesCapacity,
+		// CompactionTableSize:                   8 * opt.MiB,
+		// CompactionTotalSize:                   40 * opt.MiB,
+		// CompactionTotalSizeMultiplierPerLevel: []float64{1, 1, 10, 100, 1000, 10000, 100000},
+		// Increase table size(ldb) and total size of by using follwing options
+		//             L1   L2    L3     L4      L5       L6
+		// TableSize    4    8    16     32      64      128
+		// TotalSize  200 2000 20000 200000 2000000 20000000
+		// TableSize of level = CompactionTableSize * (CompactionTableSizeMultiplier ^ Level)
+		CompactionTableSize:           2 * opt.MiB,
+		CompactionTableSizeMultiplier: 2.0,
+		// TotalSize of level = CompactionTotalSize * (CompactionTotalSizeMultiplier ^ Level)
+		CompactionTotalSize:           20 * opt.MiB,
+		CompactionTotalSizeMultiplier: 10.0,
+	}
+	return NewGoLevelDBWithOpts(name, dir, o)
+}}
 
 func NewGoLevelDBWithOpts(name string, dir string, o *opt.Options) (*GoLevelDB, error) {
 	dbPath := filepath.Join(dir, name+".db")

--- a/goleveldb.go
+++ b/goleveldb.go
@@ -24,6 +24,8 @@ type GoLevelDB struct {
 
 var _ DB = (*GoLevelDB)(nil)
 
+// these settings were put together by the terra engineering team in their performance branch.
+// NewGoLevelDB implements DB and returns a new GoLevelDB
 func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
 	o := &opt.Options{
 		// The default value is nil

--- a/goleveldb.go
+++ b/goleveldb.go
@@ -24,9 +24,6 @@ type GoLevelDB struct {
 
 var _ DB = (*GoLevelDB)(nil)
 
-
-
-
 func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
 	o := &opt.Options{
 		// The default value is nil

--- a/goleveldb.go
+++ b/goleveldb.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
@@ -23,6 +24,9 @@ type GoLevelDB struct {
 
 var _ DB = (*GoLevelDB)(nil)
 
+
+
+
 func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
 	o := &opt.Options{
 		// The default value is nil
@@ -32,7 +36,7 @@ func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
 		// Use 64 MiB instead of default 4 MiB
 		WriteBuffer:            64 * opt.MiB,
 		DisableSeeksCompaction: true,
-		OpenFilesCacheCapacity: DefaultOpenFilesCapacity,
+		OpenFilesCacheCapacity: 32768,
 		// CompactionTableSize:                   8 * opt.MiB,
 		// CompactionTotalSize:                   40 * opt.MiB,
 		// CompactionTotalSizeMultiplierPerLevel: []float64{1, 1, 10, 100, 1000, 10000, 100000},

--- a/goleveldb.go
+++ b/goleveldb.go
@@ -48,7 +48,7 @@ func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
 		CompactionTotalSizeMultiplier: 10.0,
 	}
 	return NewGoLevelDBWithOpts(name, dir, o)
-}}
+}
 
 func NewGoLevelDBWithOpts(name string, dir string, o *opt.Options) (*GoLevelDB, error) {
 	dbPath := filepath.Join(dir, name+".db")


### PR DESCRIPTION
These are the goleveldb settings from the omnibus update branch.  

They improve performance, but not nearly as much as pebble. 