### PR TITLE
Rocksdb Settings from Omnibus update

### DIFF
--- a/rocksdb.go
+++ b/rocksdb.go
@@ -28,23 +28,48 @@ type RocksDB struct {
 
 var _ DB = (*RocksDB)(nil)
 
+// these settings were put together by the terra engineering team in their performance branch. 
+// NewRocksDB makes a new RocksDB
 func NewRocksDB(name string, dir string) (*RocksDB, error) {
 	// default rocksdb option, good enough for most cases, including heavy workloads.
 	// 1GB table cache, 512MB write buffer(may use 50% more on heavy workloads).
 	// compression: snappy as default, need to -lsnappy to enable.
-	bbto := gorocksdb.NewDefaultBlockBasedTableOptions()
-	bbto.SetBlockCache(gorocksdb.NewLRUCache(1 << 30))
-	bbto.SetFilterPolicy(gorocksdb.NewBloomFilter(10))
+	bbto := grocksdb.NewDefaultBlockBasedTableOptions()
+	cache := grocksdb.NewLRUCache(1 << 30)
+	bbto.SetBlockCache(cache)
+	filter := grocksdb.NewBloomFilter(10)
+	bbto.SetFilterPolicy(filter)
+	bbto.SetCacheIndexAndFilterBlocks(true)
+	bbto.SetPinL0FilterAndIndexBlocksInCache(true)
 
-	opts := gorocksdb.NewDefaultOptions()
+	opts := grocksdb.NewDefaultOptions()
 	opts.SetBlockBasedTableFactory(bbto)
-	// SetMaxOpenFiles to 4096 seems to provide a reliable performance boost
-	opts.SetMaxOpenFiles(4096)
+	opts.SetMaxOpenFiles(DefaultOpenFilesCapacity)
 	opts.SetCreateIfMissing(true)
 	opts.IncreaseParallelism(runtime.NumCPU())
-	// 1.5GB maximum memory use for writebuffer.
 	opts.OptimizeLevelStyleCompaction(512 * 1024 * 1024)
-	return NewRocksDBWithOptions(name, dir, opts)
+
+	dbPath := filepath.Join(dir, name+".db")
+	db, err := grocksdb.OpenDb(opts, dbPath)
+	if err != nil {
+		err = os.MkdirAll(dbPath, 0o755)
+		if err != nil {
+			return nil, err
+		}
+	}
+	ro := grocksdb.NewDefaultReadOptions()
+	wo := grocksdb.NewDefaultWriteOptions()
+	woSync := grocksdb.NewDefaultWriteOptions()
+	woSync.SetSync(true)
+	database := &RocksDB{
+		db:     db,
+		ro:     ro,
+		wo:     wo,
+		woSync: woSync,
+		cache:  cache,
+	}
+
+	return database, nil
 }
 
 func NewRocksDBWithOptions(name string, dir string, opts *gorocksdb.Options) (*RocksDB, error) {


### PR DESCRIPTION
The omnibus update branch needs to be closed. 

So I am breaking it into individual PR's that are easier to review and do not contain the removal of redundant checks mentioned in PR #250 