### PR TITLE
Update Dockerfile

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.17-bullseye AS build
+FROM golang:1.19-bullseye AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
Use go 1.19 in the dockerfile.  Don't require it in go.mod

This way, the gitpod development environment matches the most common dev config. 

