### PR TITLE
fix: memdb iterator is not protected with rlock

### DIFF
--- a/memdb_iterator.go
+++ b/memdb_iterator.go
@@ -46,9 +46,11 @@ func newMemDBIteratorMtxChoice(db *MemDB, start []byte, end []byte, reverse bool
 		db.mtx.RLock()
 	}
 	go func() {
-		if useMtx {
-			defer db.mtx.RUnlock()
-		}
+		defer func() {
+			if useMtx {
+				db.mtx.RUnlock()
+			}
+		}()
 		// Because we use [start, end) for reverse ranges, while btree uses (start, end], we need
 		// the following variables to handle some reverse iteration conditions ourselves.
 		var (


### PR DESCRIPTION
marked as draft, because it'll reveal deadlock issues in cosmos-sdk: https://github.com/cosmos/cosmos-sdk/pull/13881#issuecomment-1352462242