### PR TITLE
support create custom rocksdb db instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - remove mutex from prefixdb
+- Add `NewRocksDBWithRawDB` for easier turning the options.
 
 ## 0.6.7
 

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -53,17 +53,20 @@ func NewRocksDBWithOptions(name string, dir string, opts *gorocksdb.Options) (*R
 	if err != nil {
 		return nil, err
 	}
+	return NewRocksDBWithRawDB(db), nil
+}
+
+func NewRocksDBWithRawDB(db *gorocksdb.DB) *RocksDB {
 	ro := gorocksdb.NewDefaultReadOptions()
 	wo := gorocksdb.NewDefaultWriteOptions()
 	woSync := gorocksdb.NewDefaultWriteOptions()
 	woSync.SetSync(true)
-	database := &RocksDB{
+	return &RocksDB{
 		db:     db,
 		ro:     ro,
 		wo:     wo,
 		woSync: woSync,
 	}
-	return database, nil
 }
 
 // Get implements DB.


### PR DESCRIPTION
- for easier tuning rocksdb options.
- support open in read-only mode
  - useful in some offline commands
  - could be used in grpc-only mode, rocksdb support multi-process open in read-only mode.